### PR TITLE
MISC-751 Remove Google Analytics and HubSpot tracking scripts from documentation sites

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -51,9 +51,6 @@ const config = {
     ],
   ],
   scripts: [
-    // String format.
-    'https:////js-eu1.hs-scripts.com/25846579.js',
-    
   ],
   plugins: [
     [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,10 +43,6 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
-        gtag: {
-          trackingID: 'G-RNDFP191TE',
-          anonymizeIP: true,
-        },
       },
     ],
   ],


### PR DESCRIPTION
This PR removes all analytics and tracking scripts from the developer documentation site, including:

* **Google Analytics (`trackingID: UA-1295190-6` / `gtag: G-RNDFP191TE`)**
* **HubSpot script (`js-eu1.hs-scripts.com/25846579.js`)**

### Rationale

* The legal team has requested the removal of all tracking and analytics scripts from our websites.
* The developer documentation should remain free of marketing trackers and lead-capture tools.
* Ensures compliance with privacy and legal requirements.

### Changes

* Removed `googleAnalytics` and `gtag` configs from `docusaurus.config.js`.
* Cleared the `scripts` section to prevent HubSpot from loading.

### Impact

* No tracking or analytics are present on the documentation site.
* Brings the site into alignment with the legal team’s requirements